### PR TITLE
Replace internal anchors with Next.js Link components

### DIFF
--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import { motion } from 'framer-motion';
 import { FaGithub, FaExternalLinkAlt } from 'react-icons/fa';
 
@@ -131,18 +132,18 @@ export default function Projects() {
             More projects coming soon! I'm constantly working on new ideas and learning new technologies.
           </p>
           <div className="flex justify-center gap-4">
-            <a
+            <Link
               href="/experience"
               className="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
             >
               View Experience
-            </a>
-            <a
+            </Link>
+            <Link
               href="/"
               className="px-6 py-3 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-colors"
             >
               Back to Home
-            </a>
+            </Link>
           </div>
         </motion.div>
       </div>


### PR DESCRIPTION
## Summary
- wrap the projects page footer buttons with Next.js `Link` to keep internal navigation client-side and prefetching intact
- add the necessary `Link` import while keeping external project URLs as standard anchors

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68df2b631c148331a9984a8e33f75d85